### PR TITLE
Feature/message slide

### DIFF
--- a/src/components/molecules/Chat/index.tsx
+++ b/src/components/molecules/Chat/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Profile, UserInfo, Content, FloatButton } from 'components';
 import { ICommentState, IMessage } from 'types';
-import { useAppDispatch } from 'hooks';
+import { useAppDispatch, useAppSelector } from 'hooks';
 import { messageDeleted } from 'redux/messagesSlice';
 import * as S from './style';
 
@@ -14,6 +14,7 @@ export function Chat({ message, setComment }: IChatProps) {
   const [isHover, setIsHover] = useState<boolean>(false);
   const { userId, messageId, userName, profileImage, content, date } = message;
   const dispatch = useAppDispatch();
+  const signInUserInfo = useAppSelector((state) => state.user);
 
   const onHover = () => setIsHover(true);
   const onLeave = () => setIsHover(false);
@@ -30,7 +31,10 @@ export function Chat({ message, setComment }: IChatProps) {
     <S.Container onMouseOver={onHover} onMouseLeave={onLeave}>
       <Profile profileImage={profileImage} />
       <div>
-        <UserInfo userName={userName} date={date} />
+        <UserInfo
+          userName={signInUserInfo.userId === userId ? `*${userName}` : userName}
+          date={date}
+        />
         <Content content={content} />
       </div>
       {isHover && <FloatButton content={content} onDelete={onDelete} onComment={onComment} />}

--- a/src/components/organisms/ChatRoom/index.tsx
+++ b/src/components/organisms/ChatRoom/index.tsx
@@ -12,8 +12,9 @@ export function ChatRoom() {
     userName: '',
     content: '',
   };
-  const [comment, setComment] = useState<ICommentState>(commentInitial);
   const messages = useAppSelector((state) => state.messages);
+  const [comment, setComment] = useState<ICommentState>(commentInitial);
+  const [lastMessage, setLastMessage] = useState(messages[messages.length - 1]);
   const messageBoxRef = useRef<HTMLDivElement>(null);
 
   const scrollToBottom = () => {
@@ -23,8 +24,13 @@ export function ChatRoom() {
   };
 
   useEffect(() => {
-    scrollToBottom();
+    if (messages.length === 0) return;
+    setLastMessage(messages[messages.length - 1]);
   }, [messages]);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [lastMessage]);
 
   return (
     <S.Container>

--- a/src/components/organisms/ChatRoom/index.tsx
+++ b/src/components/organisms/ChatRoom/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useAppSelector } from 'hooks';
 import { ICommentState } from 'types';
 import { Chat, InputMessage } from 'components';
@@ -14,6 +14,17 @@ export function ChatRoom() {
   };
   const [comment, setComment] = useState<ICommentState>(commentInitial);
   const messages = useAppSelector((state) => state.messages);
+  const messageBoxRef = useRef<HTMLDivElement>(null);
+
+  const scrollToBottom = () => {
+    if (messageBoxRef.current) {
+      messageBoxRef.current.scrollTop = messageBoxRef.current.scrollHeight;
+    }
+  };
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
 
   return (
     <S.Container>
@@ -25,9 +36,11 @@ export function ChatRoom() {
         </S.Member>
       </S.TopBar>
       <S.Wrap>
-        {messages.map((message) => (
-          <Chat key={message.messageId} message={message} setComment={setComment} />
-        ))}
+        <S.MessageBox ref={messageBoxRef}>
+          {messages.map((message) => (
+            <Chat key={message.messageId} message={message} setComment={setComment} />
+          ))}
+        </S.MessageBox>
         <InputMessage replyInfo={comment} />
       </S.Wrap>
     </S.Container>

--- a/src/components/organisms/ChatRoom/style.ts
+++ b/src/components/organisms/ChatRoom/style.ts
@@ -50,6 +50,10 @@ export const Wrap = styled.div`
   flex-direction: column;
   justify-content: end;
   padding: 20px;
+  height: 100%;
+`;
+
+export const MessageBox = styled.div`
   overflow-y: scroll;
   height: 100%;
 `;

--- a/src/components/organisms/NavBar/index.tsx
+++ b/src/components/organisms/NavBar/index.tsx
@@ -10,7 +10,6 @@ export function NavBar() {
   const user = useAppSelector((state) => state.user);
   const messages = useAppSelector((state) => state.messages);
   const [searchTerm, setSearchTerm] = useState('');
-  console.log('messages', messages);
 
   return (
     <S.Container>

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -4,7 +4,6 @@ import { RegisterModal, Messenger } from 'components';
 
 export function Main() {
   const user = useAppSelector((state) => state.user);
-  const messages = useAppSelector((state) => state.messages);
 
   const [isEmpty, setIsEmpty] = useState<boolean>(true);
 
@@ -12,8 +11,7 @@ export function Main() {
     if (!user.userName) {
       setIsEmpty(true);
     }
-    console.log(messages);
-  }, [user, messages, isEmpty]);
+  }, [user, isEmpty]);
 
   return (
     <>


### PR DESCRIPTION
![Animation](https://user-images.githubusercontent.com/28294925/153579847-16dc041d-1e35-4f24-8c4e-b560dea93c19.gif)


**구현한 기능**

✔️ 입력창과는 별개로 대화목록만 스크롤 가능.
✔️ 메시지를 보낼 때 대화목록은 항상 가장 아래로 스크롤. 메시지 삭제 시에는 스크롤하지 않음. 
✔️  내가 전송한 메시지의 경우 이름 옆에 * 문자가 출력.

**구현해야 될 기능**
🔥 입력란은 멀티라인으로 입력하고 출력도 그대로 출력됩니다.

**궁금한 점**
gif를 보시면 메시지를 입력할 시 대화목록 레이아웃이 부풀어오르는? 현상을 확인하실 수 있습니다. css를 건드리면서 해결해보려 했는데 아직 원인을 잘 모르겠습니다. 짐작 가시는 부분 있으면 조언 부탁드립니다.